### PR TITLE
Bump Andy.Llm to 2026.6.7-rc.38

### DIFF
--- a/src/Andy.Engine/Andy.Engine.csproj
+++ b/src/Andy.Engine/Andy.Engine.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <PackageReference Include="Andy.Configuration" Version="2025.7.16-rc.6" />
     <PackageReference Include="Andy.Context" Version="2025.9.23-rc.4" />
-    <PackageReference Include="Andy.Llm" Version="2026.5.31-rc.36" />
+    <PackageReference Include="Andy.Llm" Version="2026.6.7-rc.38" />
     <PackageReference Include="Andy.Model" Version="2026.5.31-rc.8" />
     <PackageReference Include="Andy.Tools" Version="2025.10.16-rc.16" />
     <PackageReference Include="JsonSchema.Net" Version="7.0.0" />


### PR DESCRIPTION
Bumps `Andy.Llm` `2026.5.31-rc.36` -> `2026.6.7-rc.38`.

This picks up tool-argument JSON repair at every provider tool-call boundary: malformed tool-call arguments emitted by weaker models (markdown fences, single quotes, trailing commas, double-encoded objects, and degenerate scalars such as a bare `1`) are normalized into a valid arguments object before they reach the agent loop.

## Tests

Full unit/Mock suite green locally: **251 passed, 0 failed, 0 skipped**. (`Real`-mode benchmark cases are only generated when `OPENAI_API_KEY`/`ANTHROPIC_API_KEY` is present and exercise a live LLM; they are independent of this dependency bump.)