### PR TITLE
Fix broken-pipe failure when external agent ignores stdin

### DIFF
--- a/src/Andy.Engine.SweBench/Agent/ExternalCliAgent.cs
+++ b/src/Andy.Engine.SweBench/Agent/ExternalCliAgent.cs
@@ -86,8 +86,19 @@ public sealed class ExternalCliAgent : ISweAgent
 
             if (!usesPromptToken)
             {
-                await proc.StandardInput.WriteAsync(problemStatement);
-                proc.StandardInput.Close();
+                // A well-behaved agent may take its input from args/workspace and never read
+                // stdin, exiting (and closing the pipe) before we finish writing. That surfaces
+                // as a broken pipe on write/close and is benign — the prompt simply went
+                // unconsumed, which is the agent's choice, not a run failure.
+                try
+                {
+                    await proc.StandardInput.WriteAsync(problemStatement);
+                    proc.StandardInput.Close();
+                }
+                catch (IOException)
+                {
+                    // child closed stdin / already exited; nothing more to feed it.
+                }
             }
 
             // Drain output concurrently so a chatty agent can't deadlock on a full pipe buffer.


### PR DESCRIPTION
## Problem

`build-and-release` on `main` has been red. The failure is in `Andy.Benchmarks.PluggableAgentTests.ExternalAgent_EditsWorkspace_ReportsSuccess`:

```
System.IO.IOException : Broken pipe
  at Andy.Engine.SweBench.Agent.ExternalCliAgent.RunAsync(...) ExternalCliAgent.cs:line 89
```

When the `--agent-cmd` template has no `{prompt}`/`{prompt_file}` token, the problem statement is piped to the external agent's **stdin**. An agent that takes its input from args/workspace and never reads stdin can exit (closing the pipe) before we finish writing — surfacing as a broken pipe and failing the entire run. The failing test's script (`echo patched > "$1/fix.txt"`) does exactly that, so it failed reliably in CI and flakily (timing-dependent) elsewhere.

## Fix

Swallow `IOException` on the stdin write/close. The agent declining to read the piped prompt is its choice, not a run failure — it should still report its real outcome (exit code / stderr).

## Tests

- The existing `ExternalAgent_EditsWorkspace_ReportsSuccess` is the regression test; stress-ran the previously-failing case **15/15 green**.
- Full solution, CI-equivalent (`dotnet test -c Release`): **Andy.Benchmarks 74/74, Andy.Engine.Tests 251/251, 0 failures**.