### PR TITLE
Max-turns: concise response instead of raw history dump + wrap-up nudge

### DIFF
--- a/src/Andy.Engine/SimpleAgent.cs
+++ b/src/Andy.Engine/SimpleAgent.cs
@@ -113,6 +113,8 @@ public class SimpleAgent : IDisposable
         // final answer. Used at max-turns to avoid recording that already-interleaved message
         // a second time as Turn.AssistantMessage.
         var lastAssistantWasInterleaved = false;
+        // Whether the one-time "you're approaching the turn budget, wrap up" nudge has been sent.
+        var wrapUpNudgeSent = false;
 
         var turnCount = 0;
         var startTime = DateTime.UtcNow;
@@ -123,6 +125,30 @@ public class SimpleAgent : IDisposable
             {
                 turnCount++;
                 _logger?.LogDebug("Turn {TurnCount}/{MaxTurns}", turnCount, _maxTurns);
+
+                // As we approach the turn budget, nudge the model once to wrap up and stop
+                // exploring. This often lets it produce a final answer before the hard limit,
+                // avoiding a "max turns exceeded" stop. Mirrors the output-truncation nudge: the
+                // message is added to both the in-flight request and the interleaved log so the
+                // persisted turn faithfully reflects what was sent.
+                if (!wrapUpNudgeSent && ShouldSendWrapUpNudge(turnCount, _maxTurns))
+                {
+                    _logger?.LogInformation(
+                        "Approaching turn budget ({TurnCount}/{MaxTurns}); nudging the model to wrap up.",
+                        turnCount, _maxTurns);
+
+                    var wrapUp = new Message
+                    {
+                        Role = Role.User,
+                        Content = $"You are on turn {turnCount} of a maximum {_maxTurns} tool-call turns. "
+                                + "Stop exploring and produce your final answer now, making only the "
+                                + "essential remaining tool calls. If you cannot fully finish, summarize "
+                                + "what you have changed and what still remains.",
+                    };
+                    inFlightMessages.Add(wrapUp);
+                    allInterleavedMessages.Add(wrapUp);
+                    wrapUpNudgeSent = true;
+                }
 
                 // Build tool declarations from registry
                 var toolDeclarations = BuildToolDeclarations();
@@ -283,48 +309,24 @@ public class SimpleAgent : IDisposable
 
             _logger?.LogWarning("Reached maximum turn count ({MaxTurns})", _maxTurns);
 
-            // Build conversation history for debugging
-            var allConversationMessages = _conversationManager.Conversation.ToChronoMessages().ToList();
-            var historyBuilder = new System.Text.StringBuilder();
-            historyBuilder.AppendLine($"Reached maximum turn count ({_maxTurns})");
-            historyBuilder.AppendLine("Conversation history (FULL - no truncation):");
-            historyBuilder.AppendLine("=".PadRight(80, '='));
-            for (int i = 0; i < allConversationMessages.Count; i++)
+            // Log the full conversation for debugging, but DO NOT return it as the response.
+            // Previously the entire history — every raw tool-result payload, embedded CRLFs and all —
+            // was packed into Response, and callers (e.g. the CLI feed) rendered it verbatim, flooding
+            // the UI with tool JSON. The detail stays in the logs; callers get a concise message.
+            if (_logger?.IsEnabled(LogLevel.Warning) == true)
             {
-                var msg = allConversationMessages[i];
-                var content = msg.Content ?? "(empty)";
-                historyBuilder.AppendLine($"\n[{i}] Role: {msg.Role}");
-                historyBuilder.AppendLine($"Content: {content}");
-                historyBuilder.AppendLine($"ToolCalls Count: {msg.ToolCalls?.Count ?? 0}");
-
-                if (msg.ToolCalls != null && msg.ToolCalls.Count > 0)
+                var allConversationMessages = _conversationManager.Conversation.ToChronoMessages().ToList();
+                for (int i = 0; i < allConversationMessages.Count; i++)
                 {
-                    foreach (var toolCall in msg.ToolCalls)
-                    {
-                        historyBuilder.AppendLine($"  - Tool: {toolCall.Name}");
-                        historyBuilder.AppendLine($"    ID: {toolCall.Id}");
-                        historyBuilder.AppendLine($"    Arguments: {toolCall.ArgumentsJson}");
-                    }
+                    var msg = allConversationMessages[i];
+                    _logger.LogWarning("  [{Index}] {Role}: {Content} (ToolCalls: {ToolCallCount})",
+                        i, msg.Role, msg.Content ?? "(empty)", msg.ToolCalls?.Count ?? 0);
                 }
-
-                if (msg.ToolResults != null && msg.ToolResults.Count > 0)
-                {
-                    foreach (var toolResult in msg.ToolResults)
-                    {
-                        historyBuilder.AppendLine($"  - ToolResult: {toolResult.Name} (CallId: {toolResult.CallId}, IsError: {toolResult.IsError})");
-                    }
-                }
-                historyBuilder.AppendLine("-".PadRight(80, '-'));
-
-                // Also log to logger with full content
-                _logger?.LogWarning("  [{Index}] {Role}: {Content} (ToolCalls: {ToolCallCount})",
-                    i, msg.Role, content, msg.ToolCalls?.Count ?? 0);
             }
-            historyBuilder.AppendLine("=".PadRight(80, '='));
 
             return new SimpleAgentResult(
                 Success: false,
-                Response: historyBuilder.ToString(),
+                Response: $"Reached the maximum of {_maxTurns} tool-call turns before completing the request.",
                 TurnCount: turnCount,
                 Duration: DateTime.UtcNow - startTime,
                 StopReason: "max_turns_exceeded"
@@ -709,6 +711,18 @@ public class SimpleAgent : IDisposable
         finishReason is not null &&
         (finishReason.Equals("length", StringComparison.OrdinalIgnoreCase) ||
          finishReason.Equals("max_tokens", StringComparison.OrdinalIgnoreCase));
+
+    /// <summary>
+    /// Whether to emit the one-time "wrap up" nudge on the current turn: once the agent has used
+    /// roughly 80% of its turn budget. Skipped for very small budgets (&lt; 3) where there is no
+    /// room for a nudge to help before the hard limit.
+    /// </summary>
+    internal static bool ShouldSendWrapUpNudge(int turnCount, int maxTurns)
+    {
+        if (maxTurns < 3) return false;
+        var threshold = (int)Math.Ceiling(maxTurns * 0.8);
+        return turnCount >= threshold;
+    }
 
     private Dictionary<string, object?> ParseToolArguments(string argumentsJson)
     {

--- a/tests/Andy.Engine.Tests/SimpleAgentMaxTurnsTests.cs
+++ b/tests/Andy.Engine.Tests/SimpleAgentMaxTurnsTests.cs
@@ -1,0 +1,138 @@
+using Andy.Engine;
+using Andy.Model.Llm;
+using Andy.Model.Model;
+using Andy.Tools.Core;
+using Moq;
+using Xunit;
+
+namespace Andy.Engine.Tests;
+
+/// <summary>
+/// Behavior when the agent runs out of turn budget:
+///  - it returns a concise notice, NOT the full raw conversation-history dump (which callers used
+///    to render verbatim, flooding their UI with tool JSON / CRLFs);
+///  - as it approaches the budget it sends a one-time "wrap up" nudge so the model can finish
+///    before the hard limit.
+/// </summary>
+public class SimpleAgentMaxTurnsTests
+{
+    private const string WrapUpMarker = "produce your final answer now";
+
+    private static SimpleAgent NewAgent(ILlmProvider provider, IToolExecutor executor, int maxTurns)
+    {
+        var registry = new Mock<IToolRegistry>();
+        registry.Setup(r => r.Tools).Returns(new List<ToolRegistration>());
+        return new SimpleAgent(provider, registry.Object, executor, systemPrompt: "system", maxTurns: maxTurns);
+    }
+
+    // A provider that never finishes: every turn it emits a single tool call, forcing the agent
+    // to loop until it exhausts its turn budget.
+    private static Mock<ILlmProvider> NeverFinishingProvider(List<LlmRequest>? capture = null)
+    {
+        var provider = new Mock<ILlmProvider>();
+        var setup = provider.Setup(p => p.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()));
+        if (capture != null)
+        {
+            setup.Callback<LlmRequest, CancellationToken>((req, _) => capture.Add(req));
+        }
+        setup.ReturnsAsync(new LlmResponse
+        {
+            AssistantMessage = new Message
+            {
+                Role = Role.Assistant,
+                Content = "",
+                ToolCalls = new List<ToolCall>
+                {
+                    new ToolCall { Id = "call_1", Name = "explore", ArgumentsJson = "{}" },
+                },
+            },
+        });
+        return provider;
+    }
+
+    private static IToolExecutor AlwaysSucceedingExecutor()
+    {
+        var executor = new Mock<IToolExecutor>();
+        executor.Setup(e => e.ExecuteAsync(
+                It.IsAny<string>(), It.IsAny<Dictionary<string, object?>>(), It.IsAny<ToolExecutionContext>()))
+            .ReturnsAsync(new ToolExecutionResult { IsSuccessful = true, Data = "ok" });
+        return executor.Object;
+    }
+
+    [Theory]
+    [InlineData(10, 7, false)]
+    [InlineData(10, 8, true)]
+    [InlineData(10, 10, true)]
+    [InlineData(50, 39, false)]
+    [InlineData(50, 40, true)]
+    [InlineData(2, 2, false)]   // too small to nudge
+    [InlineData(1, 1, false)]
+    public void ShouldSendWrapUpNudge_FiresAtAboutEightyPercent(int maxTurns, int turn, bool expected)
+    {
+        Assert.Equal(expected, SimpleAgent.ShouldSendWrapUpNudge(turn, maxTurns));
+    }
+
+    [Fact]
+    public async Task MaxTurns_ReturnsConciseNotice_NotHistoryDump()
+    {
+        var provider = NeverFinishingProvider();
+        var agent = NewAgent(provider.Object, AlwaysSucceedingExecutor(), maxTurns: 3);
+
+        var result = await agent.ProcessMessageAsync("Work on the task.");
+
+        Assert.False(result.Success);
+        Assert.Equal("max_turns_exceeded", result.StopReason);
+        Assert.Equal(3, result.TurnCount);
+
+        // The response must be a clean notice, not the old raw dump.
+        Assert.DoesNotContain("Conversation history", result.Response);
+        Assert.DoesNotContain("ToolCalls Count", result.Response);
+        Assert.DoesNotContain("Role:", result.Response);
+        Assert.Contains("maximum", result.Response);
+        Assert.Contains("turns", result.Response);
+    }
+
+    [Fact]
+    public async Task WrapUpNudge_IsSentOnce_AsAgentApproachesLimit()
+    {
+        var requests = new List<LlmRequest>();
+        var provider = NeverFinishingProvider(requests);
+        // maxTurns 5 -> nudge threshold = ceil(4) = turn 4.
+        var agent = NewAgent(provider.Object, AlwaysSucceedingExecutor(), maxTurns: 5);
+
+        await agent.ProcessMessageAsync("Work on the task.");
+
+        // Early turns (before turn 4) must NOT contain the nudge.
+        Assert.DoesNotContain(
+            requests[0].Messages,
+            m => (m.Content ?? "").Contains(WrapUpMarker));
+
+        // The final request must contain the nudge exactly once (added once, then persists).
+        var lastRequest = requests[^1];
+        var nudgeCount = lastRequest.Messages.Count(m => (m.Content ?? "").Contains(WrapUpMarker));
+        Assert.Equal(1, nudgeCount);
+    }
+
+    [Fact]
+    public async Task WrapUpNudge_NotSent_WhenModelFinishesEarly()
+    {
+        var requests = new List<LlmRequest>();
+        var provider = new Mock<ILlmProvider>();
+        provider.Setup(p => p.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<LlmRequest, CancellationToken>((req, _) => requests.Add(req))
+            .ReturnsAsync(new LlmResponse
+            {
+                AssistantMessage = new Message { Role = Role.Assistant, Content = "Done." },
+                FinishReason = "stop",
+            });
+        var agent = NewAgent(provider.Object, AlwaysSucceedingExecutor(), maxTurns: 10);
+
+        var result = await agent.ProcessMessageAsync("Quick task.");
+
+        Assert.True(result.Success);
+        Assert.Equal(1, result.TurnCount);
+        Assert.DoesNotContain(
+            requests.SelectMany(r => r.Messages),
+            m => (m.Content ?? "").Contains(WrapUpMarker));
+    }
+}


### PR DESCRIPTION
## Summary
Improves `SimpleAgent`'s turn-budget behavior. Addresses the root cause behind the andy-cli "wall of raw tool JSON / CRLFs" report (rivoli-ai/andy-cli#111) and implements the wrap-up nudge tracked in rivoli-ai/andy-cli#113.

### 1. Don't return the raw conversation-history dump
On `max_turns_exceeded`, the agent packed the **entire** conversation history — every raw tool-result payload (including embedded `\r\n` from e.g. an HTTP error body) and full file contents — into `SimpleAgentResult.Response`. Callers render that verbatim, flooding their UI. The full history is still written to the logs; `Response` is now a concise notice ("Reached the maximum of N tool-call turns before completing the request.").

### 2. Wrap-up nudge as the budget runs low (andy-cli#113)
Once the agent has used ~80% of its turn budget, it injects a one-time user message telling the model to stop exploring and produce its final answer (or summarize remaining work). This often lets it finish before the hard limit. Mirrors the existing output-truncation nudge and is persisted in the interleaved turn log the same way. Skipped for budgets < 3 turns.

## Tests
New `SimpleAgentMaxTurnsTests` (10):
- max-turns response is a concise notice, not the dump (asserts absence of `Conversation history` / `ToolCalls Count` / `Role:`);
- `ShouldSendWrapUpNudge` threshold (~80%) across budgets incl. the small-budget guard;
- the nudge is delivered exactly once and persists in later requests;
- no nudge when the model finishes early.

All 53 `SimpleAgent` tests pass locally (history-fidelity regressions included).

## Notes
- Context **compaction / continue-across-turns** (andy-cli#114) is intentionally NOT in this PR — the existing `IContextCompressor` only fits prior context to the token budget; true continue-across-turns is a larger, separate design.
- Once merged to `main`, CI publishes a new `Andy.Engine` RC; andy-cli will be bumped to consume it.