### PR TITLE
fix: deserialize nested JSON tool-call arguments into dictionaries/lists

### DIFF
--- a/src/Andy.Engine/SimpleAgent.cs
+++ b/src/Andy.Engine/SimpleAgent.cs
@@ -764,17 +764,7 @@ public class SimpleAgent : IDisposable
 
             foreach (var property in root.EnumerateObject())
             {
-                args[property.Name] = property.Value.ValueKind switch
-                {
-                    JsonValueKind.String => property.Value.GetString(),
-                    JsonValueKind.Number => property.Value.GetDouble(),
-                    JsonValueKind.True => true,
-                    JsonValueKind.False => false,
-                    JsonValueKind.Null => null,
-                    JsonValueKind.Object => property.Value.GetRawText(),
-                    JsonValueKind.Array => DeserializeArray(property.Value),
-                    _ => property.Value.GetRawText()
-                };
+                args[property.Name] = ConvertElement(property.Value);
             }
             return true;
         }
@@ -831,33 +821,47 @@ public class SimpleAgent : IDisposable
     private static readonly System.Text.RegularExpressions.Regex TrailingCommaRegex =
         new(@",(\s*[}\]])", System.Text.RegularExpressions.RegexOptions.Compiled);
 
+    // Recursively converts a JSON element to a plain CLR value: objects become
+    // Dictionary<string, object?>, arrays become string[]/object?[], scalars become their CLR type.
+    // Preserving nested structure is what lets tools with object/array parameters — e.g. the
+    // dataframe_* tools' 'predicate', 'aggregations', 'expression' — receive real dictionaries and
+    // lists instead of raw JSON text (which the tools reject as "must be an object").
+    private static object? ConvertElement(JsonElement element) => element.ValueKind switch
+    {
+        JsonValueKind.String => element.GetString(),
+        JsonValueKind.Number => element.GetDouble(),
+        JsonValueKind.True => true,
+        JsonValueKind.False => false,
+        JsonValueKind.Null => null,
+        JsonValueKind.Object => DeserializeObject(element),
+        JsonValueKind.Array => DeserializeArray(element),
+        _ => element.GetRawText()
+    };
+
+    private static Dictionary<string, object?> DeserializeObject(JsonElement objectElement)
+    {
+        var result = new Dictionary<string, object?>(StringComparer.Ordinal);
+        foreach (var property in objectElement.EnumerateObject())
+        {
+            result[property.Name] = ConvertElement(property.Value);
+        }
+        return result;
+    }
+
     private static object DeserializeArray(JsonElement arrayElement)
     {
-        // Try to deserialize as string array first (most common case)
-        var items = new List<object>();
+        var items = new List<object?>();
         foreach (var item in arrayElement.EnumerateArray())
         {
-            items.Add(item.ValueKind switch
-            {
-                JsonValueKind.String => item.GetString() ?? string.Empty,
-                JsonValueKind.Number => item.GetDouble(),
-                JsonValueKind.True => true,
-                JsonValueKind.False => false,
-                JsonValueKind.Null => null!,
-                JsonValueKind.Object => item.GetRawText(),
-                JsonValueKind.Array => DeserializeArray(item),
-                _ => item.GetRawText()
-            });
+            items.Add(ConvertElement(item));
         }
 
-        // If all items are strings, return as string array
-        if (items.All(x => x is string))
-        {
-            return items.Cast<string>().ToArray();
-        }
-
-        // Otherwise return as object array
-        return items.ToArray();
+        // Keep a string[] when every element is a string (back-compat for string-array params like
+        // group_by / columns); otherwise return object?[], preserving nested dictionaries so arrays
+        // of objects (aggregations, sort keys, expectations, window functions) survive intact.
+        return items.All(x => x is string)
+            ? items.Cast<string>().ToArray()
+            : items.ToArray();
     }
 
     public void Dispose()

--- a/tests/Andy.Engine.Tests/SimpleAgentToolArgumentTests.cs
+++ b/tests/Andy.Engine.Tests/SimpleAgentToolArgumentTests.cs
@@ -1,0 +1,89 @@
+using Andy.Engine;
+using Andy.Model.Llm;
+using Andy.Model.Model;
+using Andy.Tools.Core;
+using Moq;
+using Xunit;
+
+namespace Andy.Engine.Tests;
+
+/// <summary>
+/// LLM tool calls arrive as a JSON arguments string. This verifies the agent deserializes nested
+/// JSON into real CLR dictionaries and lists (not raw JSON text), so tools with object/array
+/// parameters — e.g. the dataframe_* tools' 'predicate', 'aggregations', 'having' — receive usable
+/// structures. Regression for "Parameter 'predicate' must be an object" and an 'aggregations'
+/// argument arriving as System.String[].
+/// </summary>
+public class SimpleAgentToolArgumentTests
+{
+    [Fact]
+    public async Task Nested_json_tool_arguments_become_dictionaries_and_lists()
+    {
+        var registry = new Mock<IToolRegistry>();
+        registry.Setup(r => r.Tools).Returns(new List<ToolRegistration>
+        {
+            new()
+            {
+                IsEnabled = true,
+                Metadata = new ToolMetadata { Id = "dataframe_group_by", Name = "Group By", Description = "Groups rows." },
+            },
+        });
+
+        // Capture the parameters the executor actually receives.
+        Dictionary<string, object?>? captured = null;
+        var executor = new Mock<IToolExecutor>();
+        executor.Setup(e => e.ExecuteAsync(
+                It.IsAny<string>(), It.IsAny<Dictionary<string, object?>>(), It.IsAny<ToolExecutionContext>()))
+            .Callback<string, Dictionary<string, object?>, ToolExecutionContext>((_, p, _) => captured = p)
+            .ReturnsAsync(new ToolExecutionResult { IsSuccessful = true, Data = "ok" });
+
+        // A realistic group_by call: a string array (group_by), an array of objects (aggregations),
+        // and a nested object (having).
+        const string argsJson =
+            "{\"dataset_id\":\"sales\",\"group_by\":[\"region\"]," +
+            "\"aggregations\":[{\"column\":\"amount\",\"function\":\"sum\",\"alias\":\"total\"}]," +
+            "\"having\":{\"column\":\"total\",\"op\":\"gt\",\"value\":100}}";
+
+        var provider = new Mock<ILlmProvider>();
+        provider.SetupSequence(p => p.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LlmResponse
+            {
+                AssistantMessage = new Message
+                {
+                    Role = Role.Assistant,
+                    Content = "",
+                    ToolCalls = new List<ToolCall>
+                    {
+                        new() { Id = "c1", Name = "dataframe_group_by", ArgumentsJson = argsJson },
+                    },
+                },
+            })
+            .ReturnsAsync(new LlmResponse
+            {
+                AssistantMessage = new Message { Role = Role.Assistant, Content = "Done." },
+                FinishReason = "stop",
+            });
+
+        var agent = new SimpleAgent(provider.Object, registry.Object, executor.Object, "system", maxTurns: 5);
+        await agent.ProcessMessageAsync("group it");
+
+        Assert.NotNull(captured);
+
+        // String arrays still come through as a string array.
+        var groupBy = Assert.IsAssignableFrom<IEnumerable<string>>(captured!["group_by"]);
+        Assert.Equal(new[] { "region" }, groupBy);
+
+        // Arrays of objects survive as a list of dictionaries (NOT a string[] of raw JSON).
+        var aggregations = Assert.IsAssignableFrom<System.Collections.IEnumerable>(captured["aggregations"])
+            .Cast<object?>().ToList();
+        var agg = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(Assert.Single(aggregations));
+        Assert.Equal("amount", agg["column"]);
+        Assert.Equal("sum", agg["function"]);
+        Assert.Equal("total", agg["alias"]);
+
+        // Nested objects survive as a dictionary (NOT a raw JSON string).
+        var having = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(captured["having"]);
+        Assert.Equal("total", having["column"]);
+        Assert.Equal("gt", having["op"]);
+    }
+}


### PR DESCRIPTION
## Problem

LLM tool-call arguments arrive as a JSON string. `SimpleAgent` decoded them with:
- nested **objects** → `JsonElement.GetRawText()` (a raw JSON **string**)
- **arrays of objects** → a `string[]` of raw JSON (then collapsed via the "all strings" branch)

Tools with object/array parameters then rejected the values. The `dataframe_*` tools, the first heavy users of structured params, failed with:
- `Parameter 'predicate' must be an object`
- `Each aggregation must be a { column, function, alias, q?, column2? } object` (arg shown as `System.String[]`)

Scalar/string-array tools (`read_file`, `execute_command`, …) only use scalars and string arrays, so the gap went unnoticed. (The agent "worked around" it by dumping rows via `dataframe_preview` and computing in text.)

## Fix

Deserialize JSON **recursively**: objects → `Dictionary<string, object?>`, arrays → `string[]` when every element is a string (back-compat for `group_by`/`columns`) else `object?[]` preserving nested dictionaries. This matches what the Andy.Data validator/parsers expect (`IReadOnlyDictionary` / non-string `IEnumerable`).

## Test

`SimpleAgentToolArgumentTests` drives a real `SimpleAgent` with a `group_by`-style call (string array + array of objects + nested object) and asserts the executor receives real dictionaries/lists. All 55 `SimpleAgent` tests pass.

## Rollout

Engine fix → publish a new `Andy.Engine` RC → bump `andy-cli`'s `Andy.Engine` reference so the CLI agent marshals structured args correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)