### PR TITLE
SimpleAgent: thread LlmRequest.ExtraBody (provider routing passthrough)

### DIFF
--- a/src/Andy.Engine/Andy.Engine.csproj
+++ b/src/Andy.Engine/Andy.Engine.csproj
@@ -37,9 +37,9 @@
   <ItemGroup>
     <PackageReference Include="Andy.Configuration" Version="2025.7.16-rc.6" />
     <PackageReference Include="Andy.Context" Version="2025.9.23-rc.4" />
-    <PackageReference Include="Andy.Llm" Version="2026.6.7-rc.38" />
-    <PackageReference Include="Andy.Model" Version="2026.5.31-rc.8" />
-    <PackageReference Include="Andy.Tools" Version="2026.6.16-rc.69" />
+    <PackageReference Include="Andy.Llm" Version="2026.6.20-rc.1" />
+    <PackageReference Include="Andy.Model" Version="2026.6.19-rc.2" />
+    <PackageReference Include="Andy.Tools" Version="2026.6.20-rc.77" />
     <PackageReference Include="JsonSchema.Net" Version="7.0.0" />
     <PackageReference Include="JsonPointer.Net" Version="5.0.0" />
     <PackageReference Include="Polly" Version="8.5.2" />

--- a/src/Andy.Engine/Andy.Engine.csproj
+++ b/src/Andy.Engine/Andy.Engine.csproj
@@ -37,8 +37,8 @@
   <ItemGroup>
     <PackageReference Include="Andy.Configuration" Version="2025.7.16-rc.6" />
     <PackageReference Include="Andy.Context" Version="2025.9.23-rc.4" />
-    <PackageReference Include="Andy.Llm" Version="2026.6.20-rc.1" />
-    <PackageReference Include="Andy.Model" Version="2026.6.19-rc.2" />
+    <PackageReference Include="Andy.Llm" Version="2026.6.20-rc.42" />
+    <PackageReference Include="Andy.Model" Version="2026.6.20-rc.10" />
     <PackageReference Include="Andy.Tools" Version="2026.6.20-rc.77" />
     <PackageReference Include="JsonSchema.Net" Version="7.0.0" />
     <PackageReference Include="JsonPointer.Net" Version="5.0.0" />

--- a/src/Andy.Engine/SimpleAgent.cs
+++ b/src/Andy.Engine/SimpleAgent.cs
@@ -32,6 +32,7 @@ public class SimpleAgent : IDisposable
     private readonly IContextCompressor _contextCompressor;
     private readonly bool _enablePromptCaching;
     private readonly string _workingDirectory;
+    private readonly IReadOnlyDictionary<string, object?>? _extraBody;
     private IConversationManager _conversationManager;
 
     public SimpleAgent(
@@ -47,7 +48,8 @@ public class SimpleAgent : IDisposable
         int maxToolResultChars = 16000,
         int maxContextTokens = 120_000,
         IContextCompressor? contextCompressor = null,
-        bool enablePromptCaching = true)
+        bool enablePromptCaching = true,
+        IReadOnlyDictionary<string, object?>? extraBody = null)
     {
         _llmProvider = llmProvider ?? throw new ArgumentNullException(nameof(llmProvider));
         _toolRegistry = toolRegistry ?? throw new ArgumentNullException(nameof(toolRegistry));
@@ -59,6 +61,7 @@ public class SimpleAgent : IDisposable
         _maxContextTokens = maxContextTokens > 0 ? maxContextTokens : 120_000;
         _contextCompressor = contextCompressor ?? new SmartCompressor();
         _enablePromptCaching = enablePromptCaching;
+        _extraBody = extraBody;
         _workingDirectory = workingDirectory ?? Environment.CurrentDirectory;
         _logger = logger;
         _conversationManager = conversationManager ?? new DefaultConversationManager();
@@ -164,6 +167,9 @@ public class SimpleAgent : IDisposable
                     // OpenAI/DeepSeek; emits an Anthropic cache_control breakpoint). The system
                     // prompt is byte-stable for the agent's lifetime, unlike the compacted history.
                     CacheSystemPrompt = _enablePromptCaching,
+                    // Provider-specific request fields (e.g. OpenRouter `provider` routing), passed
+                    // straight through to the LLM provider that knows how to serialize them.
+                    ExtraBody = _extraBody,
                     Config = new LlmClientConfig
                     {
                         // Temperature defaults to null, allowing models to use their own defaults

--- a/tests/Andy.Engine.Tests/SimpleAgentToolDeclarationTests.cs
+++ b/tests/Andy.Engine.Tests/SimpleAgentToolDeclarationTests.cs
@@ -107,4 +107,31 @@ public class SimpleAgentToolDeclarationTests
         var items = Assert.IsAssignableFrom<IDictionary<string, object>>(columns["items"]);
         Assert.Equal("string", items["type"]);
     }
+
+    [Fact]
+    public async Task ExtraBody_flows_through_to_the_llm_request()
+    {
+        var registry = new Mock<IToolRegistry>();
+        registry.Setup(r => r.Tools).Returns(new List<ToolRegistration>());
+
+        // OpenRouter-style provider routing supplied at the engine boundary.
+        var routing = new Dictionary<string, object?>
+        {
+            ["provider"] = new Dictionary<string, object?>
+            {
+                ["order"] = new[] { "deepinfra/turbo" },
+                ["allow_fallbacks"] = false
+            }
+        };
+
+        var requests = new List<LlmRequest>();
+        var agent = new SimpleAgent(
+            FinishingProvider(requests).Object, registry.Object, NoopExecutor(),
+            systemPrompt: "system", maxTurns: 5, extraBody: routing);
+
+        await agent.ProcessMessageAsync("hi");
+
+        // The dictionary the caller passed reaches LlmRequest.ExtraBody unchanged.
+        Assert.Same(routing, Assert.Single(requests).ExtraBody);
+    }
 }


### PR DESCRIPTION
Threads `LlmRequest.ExtraBody` through `SimpleAgent` via a trailing optional `extraBody` ctor arg (non-breaking for the ~17 direct call sites), so callers can pass OpenRouter `provider` routing / `models` fallbacks / `reasoning` down to the LLM provider. A test asserts the dictionary reaches `LlmRequest.ExtraBody` unchanged.

**Chain (blocked → draft):** needs `Andy.Model` with `LlmRequest.ExtraBody` (rivoli-ai/andy-model#2) and an andy-llm that emits it (rivoli-ai/andy-llm#10). The csproj bumps here are local-feed placeholders; repoint to the published versions once those ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
