### PR TITLE
Only apply the default execution-time cap to tools without their own timeout

### DIFF
--- a/src/Andy.Engine/SimpleAgent.cs
+++ b/src/Andy.Engine/SimpleAgent.cs
@@ -383,6 +383,39 @@ public class SimpleAgent : IDisposable
     /// others), but <see cref="OperationCanceledException"/> is rethrown so a cancellation
     /// cancels the whole run rather than being masked as a tool error.
     /// </summary>
+    /// <summary>
+    /// True when the named tool declares its own timeout parameter (a parameter whose name contains
+    /// "timeout", e.g. execute_command's <c>timeout_seconds</c>). Such tools enforce their own
+    /// execution limit, so the engine must not impose its default execution-time cap on top - that
+    /// would override the tool's timeout and kill legitimate long-running work.
+    /// </summary>
+    private bool ToolDeclaresOwnTimeout(string toolName)
+    {
+        try
+        {
+            var parameters = _toolRegistry.GetTool(toolName)?.Metadata?.Parameters;
+            if (parameters == null)
+            {
+                return false;
+            }
+
+            foreach (var p in parameters)
+            {
+                if (!string.IsNullOrEmpty(p.Name) &&
+                    p.Name.IndexOf("timeout", StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     private async Task<Message> ExecuteToolCallAsync(Andy.Model.Model.ToolCall toolCall, CancellationToken cancellationToken)
     {
         _logger?.LogDebug("Executing tool: {ToolName}", toolCall.Name);
@@ -400,6 +433,21 @@ public class SimpleAgent : IDisposable
             // Parse tool arguments
             var args = ParseToolArguments(toolCall.ArgumentsJson);
 
+            // The default 100MB memory cap is measured process-wide and is exceeded by the .NET
+            // runtime alone, producing spurious "resource limit exceeded" warnings on ordinary
+            // file ops - so raise it.
+            var resourceLimits = new ToolResourceLimits { MaxMemoryBytes = 2L * 1024 * 1024 * 1024 };
+
+            // The framework also imposes a default 30s execution-time cap. Only keep it for tools
+            // that do NOT manage their own timeout. A tool that declares a timeout parameter (e.g.
+            // execute_command's timeout_seconds) enforces its own limit; layering the engine's 30s
+            // cap on top would override it and kill legitimate long-running work (builds, test runs,
+            // indexing). For those tools, leave the cap unbounded so the tool's own timeout governs.
+            if (ToolDeclaresOwnTimeout(toolCall.Name))
+            {
+                resourceLimits.MaxExecutionTimeMs = 0; // unbounded - the tool enforces its own timeout
+            }
+
             // Execute tool
             var toolResult = await _toolExecutor.ExecuteAsync(
                 toolCall.Name,
@@ -409,10 +457,7 @@ public class SimpleAgent : IDisposable
                     WorkingDirectory = _workingDirectory,
                     Environment = new Dictionary<string, string>(),
                     CancellationToken = cancellationToken,
-                    // The default 100MB cap is measured process-wide and is
-                    // exceeded by the .NET runtime alone, producing spurious
-                    // "resource limit exceeded" warnings on ordinary file ops.
-                    ResourceLimits = new ToolResourceLimits { MaxMemoryBytes = 2L * 1024 * 1024 * 1024 }
+                    ResourceLimits = resourceLimits
                 }
             );
 

--- a/tests/Andy.Engine.Tests/SimpleAgentToolTimeoutTests.cs
+++ b/tests/Andy.Engine.Tests/SimpleAgentToolTimeoutTests.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Andy.Engine;
+using Andy.Model.Llm;
+using Andy.Model.Model;
+using Andy.Tools.Core;
+using Moq;
+using Xunit;
+
+namespace Andy.Engine.Tests;
+
+/// <summary>
+/// The framework imposes a default 30s per-tool execution cap via
+/// <see cref="ToolResourceLimits.MaxExecutionTimeMs"/>. The agent must only keep that cap for tools
+/// that do NOT manage their own timeout. A tool that declares a timeout parameter (e.g.
+/// execute_command's <c>timeout_seconds</c>) enforces its own limit, so the engine leaves the cap
+/// unbounded - otherwise the 30s cap would override the tool's timeout and kill long-running work.
+/// </summary>
+public class SimpleAgentToolTimeoutTests
+{
+    private static async Task<ToolExecutionContext?> RunAndCaptureContextAsync(ToolMetadata toolMeta)
+    {
+        var registration = new ToolRegistration { IsEnabled = true, Metadata = toolMeta };
+
+        var registry = new Mock<IToolRegistry>();
+        registry.Setup(r => r.Tools).Returns(new List<ToolRegistration> { registration });
+        registry.Setup(r => r.GetTool(toolMeta.Id)).Returns(registration);
+
+        ToolExecutionContext? captured = null;
+        var executor = new Mock<IToolExecutor>();
+        executor.Setup(e => e.ExecuteAsync(
+                It.IsAny<string>(), It.IsAny<Dictionary<string, object?>>(), It.IsAny<ToolExecutionContext>()))
+            .Callback<string, Dictionary<string, object?>, ToolExecutionContext>((_, _, ctx) => captured = ctx)
+            .ReturnsAsync(new ToolExecutionResult { IsSuccessful = true, Data = "ok" });
+
+        var provider = new Mock<ILlmProvider>();
+        provider.SetupSequence(p => p.CompleteAsync(It.IsAny<LlmRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LlmResponse
+            {
+                AssistantMessage = new Message
+                {
+                    Role = Role.Assistant,
+                    Content = "",
+                    ToolCalls = new List<ToolCall>
+                    {
+                        new() { Id = "c1", Name = toolMeta.Id, ArgumentsJson = "{}" },
+                    },
+                },
+            })
+            .ReturnsAsync(new LlmResponse
+            {
+                AssistantMessage = new Message { Role = Role.Assistant, Content = "Done." },
+                FinishReason = "stop",
+            });
+
+        var agent = new SimpleAgent(provider.Object, registry.Object, executor.Object, "system", maxTurns: 5);
+        await agent.ProcessMessageAsync("go");
+        return captured;
+    }
+
+    [Fact]
+    public async Task ToolWithTimeoutParameter_GetsUnboundedExecutionCap()
+    {
+        var meta = new ToolMetadata
+        {
+            Id = "execute_command",
+            Name = "Execute Command",
+            Description = "Runs a shell command.",
+            Parameters = new List<ToolParameter>
+            {
+                new() { Name = "command", Type = "string", Required = true },
+                new() { Name = "timeout_seconds", Type = "integer", Required = false },
+            },
+        };
+
+        var ctx = await RunAndCaptureContextAsync(meta);
+
+        Assert.NotNull(ctx);
+        Assert.NotNull(ctx!.ResourceLimits);
+        Assert.Equal(0, ctx.ResourceLimits!.MaxExecutionTimeMs); // unbounded - tool enforces its own timeout
+    }
+
+    [Fact]
+    public async Task ToolWithoutTimeoutParameter_KeepsDefaultExecutionCap()
+    {
+        var meta = new ToolMetadata
+        {
+            Id = "read_file",
+            Name = "Read File",
+            Description = "Reads a file.",
+            Parameters = new List<ToolParameter>
+            {
+                new() { Name = "file_path", Type = "string", Required = true },
+            },
+        };
+
+        var ctx = await RunAndCaptureContextAsync(meta);
+
+        Assert.NotNull(ctx);
+        Assert.NotNull(ctx!.ResourceLimits);
+        Assert.True(ctx.ResourceLimits!.MaxExecutionTimeMs > 0,
+            "a tool without its own timeout should keep the default execution-time backstop");
+    }
+}


### PR DESCRIPTION
## Problem
`SimpleAgent` builds each tool's `ToolExecutionContext` with `new ToolResourceLimits { MaxMemoryBytes = 2GB }`, which leaves `MaxExecutionTimeMs` at the framework's **30s default**. `ToolExecutor` enforces that as a hard `CancelAfter` linked into every tool — so a tool that manages its **own** timeout (e.g. `execute_command`'s `timeout_seconds`, often set to 600) is still killed at ~30s, aborting legitimate long-running work (builds, test runs, code indexing).

## Fix
Only keep the engine's default execution-time cap for tools that do **not** declare their own timeout. When a tool's metadata declares a timeout parameter (a parameter whose name contains "timeout"), leave `MaxExecutionTimeMs` **unbounded (0)** so the tool's own timeout governs. Tools without their own timeout keep the default backstop unchanged.

## Tests
`SimpleAgentToolTimeoutTests`: a tool with a `timeout_seconds` parameter gets an unbounded cap (0); a tool without one keeps the default (>0). Non-Benchmarks suite: 59 passed.

## Context
andy-cli shipped a CLI-side workaround (rivoli-ai/andy-cli#150) that raises the cap in its dispatch wrapper; this fixes the root in the engine so all consumers benefit. Once released + bumped, the CLI workaround can be simplified or removed.