### PR TITLE
feat: bundle + register Andy.Tools.Pdf (pdf_* tools)

### DIFF
--- a/src/Andy.Engine.SweBench/Agent/SweAgentFactory.cs
+++ b/src/Andy.Engine.SweBench/Agent/SweAgentFactory.cs
@@ -105,6 +105,10 @@ public sealed class SweAgentFactory : ISweAgentFactory
             options.DefaultPermissions.NetworkAccess = false;
         });
 
+        // Read-only PDF document tools (pdf_*) over the managed Andy.Doc engine. They require only
+        // filesystem-read, so they operate within the workspace-scoped permissions above.
+        Andy.Tools.Pdf.ServiceCollectionExtensions.AddAndyPdfTools(services);
+
         var provider = services.BuildServiceProvider();
 
         var lifecycle = provider.GetRequiredService<IToolLifecycleManager>();

--- a/src/Andy.Engine/Andy.Engine.csproj
+++ b/src/Andy.Engine/Andy.Engine.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Andy.Llm" Version="2026.6.20-rc.42" />
     <PackageReference Include="Andy.Model" Version="2026.6.20-rc.10" />
     <PackageReference Include="Andy.Tools" Version="2026.6.20-rc.77" />
+    <PackageReference Include="Andy.Tools.Pdf" Version="2026.6.22-rc.1" />
     <PackageReference Include="JsonSchema.Net" Version="7.0.0" />
     <PackageReference Include="JsonPointer.Net" Version="5.0.0" />
     <PackageReference Include="Polly" Version="8.5.2" />


### PR DESCRIPTION
Adds the `Andy.Tools.Pdf` RC package to the Engine's dependency closure and registers the read-only `pdf_*` tools where the engine repo composes its tool set (`SweAgentFactory`). The tools need only filesystem-read, within the existing workspace-scoped permissions.

**Gated on publish:** references `Andy.Tools.Pdf 2026.6.22-rc.1`, which depends transitively on `Andy.Doc.*`. CI will fail to restore until those are published to NuGet (rivoli-ai/andy-pdf#541 + andy-tools#92). Verified locally against a staged RC feed (builds clean). Merge after the packages publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)