### PR TITLE
Update Andy.Tools packages to rc.86

### DIFF
--- a/src/Andy.Engine/Andy.Engine.csproj
+++ b/src/Andy.Engine/Andy.Engine.csproj
@@ -39,8 +39,8 @@
     <PackageReference Include="Andy.Context" Version="2026.5.16-rc.6" />
     <PackageReference Include="Andy.Llm" Version="2026.7.21-rc.76" />
     <PackageReference Include="Andy.Model" Version="2026.7.21-rc.13" />
-    <PackageReference Include="Andy.Tools" Version="2026.7.21-rc.84" />
-    <PackageReference Include="Andy.Tools.Pdf" Version="2026.7.21-rc.84" />
+    <PackageReference Include="Andy.Tools" Version="2026.7.21-rc.86" />
+    <PackageReference Include="Andy.Tools.Pdf" Version="2026.7.21-rc.86" />
     <PackageReference Include="JsonSchema.Net" Version="7.0.0" />
     <PackageReference Include="JsonPointer.Net" Version="5.0.0" />
     <PackageReference Include="Polly" Version="8.5.2" />

--- a/tests/Andy.Engine.Tests/Andy.Engine.Tests.csproj
+++ b/tests/Andy.Engine.Tests/Andy.Engine.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Moq" Version="4.20.69" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <!-- Test-only: drive the real dataframe_* tools through SimpleAgent for an end-to-end scenario. -->
-    <PackageReference Include="Andy.Tools.Data" Version="2026.7.21-rc.84" />
+    <PackageReference Include="Andy.Tools.Data" Version="2026.7.21-rc.86" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Updates Andy.Tools, Andy.Tools.Pdf, and the test-only Andy.Tools.Data reference to 2026.7.21-rc.86 so Engine consumes the final dependency refresh published from andy-tools.\n\nValidation:\n- dotnet restore Andy.Engine.sln using the published workflow artifacts plus NuGet.org\n- dotnet test Andy.Engine.sln --no-restore (360 passed)\n- dotnet format Andy.Engine.sln --no-restore --verify-no-changes was attempted but the SDK formatter timed out connecting to its Roslyn named pipe before loading the solution\n- git diff --check